### PR TITLE
Hook up email_order -> sales_order FK relationship in split db mode

### DIFF
--- a/etc/constraints.xml
+++ b/etc/constraints.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework-foreign-key:etc/constraints.xsd">
+    <entity name="email_order" resource="default">
+        <constraint name="email_order_to_sales_order" onDelete="CASCADE" referenceEntity="sales_order">
+            <field name="order_id" reference="entity_id"/>
+        </constraint>
+    </entity>
+</config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -14,4 +14,21 @@
         <plugin name="ddg_customer_segment_resource" type="Dotdigitalgroup\Enterprise\Plugin\SegmentPlugin"
                 sortOrder="1"/>
     </type>
+    <type name="Magento\Framework\ForeignKey\ConstraintProcessor">
+        <arguments>
+            <argument name="strategies" xsi:type="array">
+                <item name="CASCADE" xsi:type="object">Magento\Framework\ForeignKey\Strategy\Cascade</item>
+                <item name="RESTRICT" xsi:type="object">Magento\Framework\ForeignKey\Strategy\Restrict</item>
+                <item name="SET NULL" xsi:type="object">Magento\Framework\ForeignKey\Strategy\SetNull</item>
+                <item name="NO ACTION" xsi:type="object">Magento\Framework\ForeignKey\Strategy\NoAction</item>
+                <item name="DB CASCADE" xsi:type="object">Magento\Framework\ForeignKey\Strategy\DbCascade</item>
+                <item name="DB RESTRICT" xsi:type="object">Magento\Framework\ForeignKey\Strategy\DbIgnore</item>
+                <item name="DB SET NULL" xsi:type="object">Magento\Framework\ForeignKey\Strategy\DbIgnore</item>
+                <item name="DB NO ACTION" xsi:type="object">Magento\Framework\ForeignKey\Strategy\DbIgnore</item>
+            </argument>
+        </arguments>
+    </type>
+    <type name="Magento\Framework\Model\ResourceModel\Db\ObjectRelationProcessor">
+        <plugin name="object_constraints_resolver" type="Magento\Framework\ForeignKey\ObjectRelationProcessor\Plugin" />
+    </type>
 </config>


### PR DESCRIPTION
As discussed, this is slightly academic as you can't delete orders through default Magneto UI.

But, it's a small change and will satisfy Magento architect's review.

I'm keen to hear your thoughts.